### PR TITLE
Scan card optional

### DIFF
--- a/src/components/addCard/index.js
+++ b/src/components/addCard/index.js
@@ -210,45 +210,50 @@ export default class AddCard extends Component {
         <View style={styles.errorTextContainer}>
           <Text style={styles.errorText}>{calculatedState.error}</Text>
         </View>
-        <TouchableOpacity
-          style={styles.scanCardButton}
-          styles={styles}
-          onPress={() => {
-            if (this.props.onScanCardOpen) {
-              this.props.onScanCardOpen()
-            }
-            if (Platform.OS === 'android') {
-              CardIOModule
-                .scanCard({
-                  // guideColor: this.props.scanCardGuideColor, // This isn't working at the moment.
-                  hideCardIOLogo: true,
-                  suppressManualEntry: true,
-                  suppressConfirmation: true,
-                })
-                .then((card) => this.didScanCard(card))
-                .catch(() => {
-                  let refToFocus
-                  if (!calculatedState.cardNumber) {
-                    refToFocus = this.refs.cardNumberInput
-                  } else if (!calculatedState.expiry) {
-                    refToFocus = this.refs.expiryInput
-                  } else {
-                    refToFocus = this.refs.cvcInput
-                  }
-                  // Make sure keyboard stays open on android.
-                  _.delay(() => refToFocus.blur(), DELAY_FOCUS / 2)
-                  _.delay(() => refToFocus.focus(), DELAY_FOCUS)
-                })
-            } else {
-              this.setState({ scanningCard: true })
-            }
-          }}
-          last
-        >
+        {
+          this.props.scanCardVisible ?
+          <TouchableOpacity
+            style={styles.scanCardButton}
+            styles={styles}
+            onPress={() => {
+              if (this.props.onScanCardOpen) {
+                this.props.onScanCardOpen()
+              }
+              if (Platform.OS === 'android') {
+                CardIOModule
+                  .scanCard({
+                    // guideColor: this.props.scanCardGuideColor, // This isn't working at the moment.
+                    hideCardIOLogo: true,
+                    suppressManualEntry: true,
+                    suppressConfirmation: true,
+                  })
+                  .then((card) => this.didScanCard(card))
+                  .catch(() => {
+                    let refToFocus
+                    if (!calculatedState.cardNumber) {
+                      refToFocus = this.refs.cardNumberInput
+                    } else if (!calculatedState.expiry) {
+                      refToFocus = this.refs.expiryInput
+                    } else {
+                      refToFocus = this.refs.cvcInput
+                    }
+                    // Make sure keyboard stays open on android.
+                    _.delay(() => refToFocus.blur(), DELAY_FOCUS / 2)
+                    _.delay(() => refToFocus.focus(), DELAY_FOCUS)
+                  })
+              } else {
+                this.setState({ scanningCard: true })
+              }
+            }}
+            last
+          >
           <Text style={styles.scanCardButtonText}>
             {calculatedState.hasTriedScan ? this.props.scanCardAfterScanButtonText : this.props.scanCardButtonText}
           </Text>
-        </TouchableOpacity>
+          </TouchableOpacity>
+        : null
+        }
+
         <TouchableOpacity
           style={styles.addButton}
           styles={styles}

--- a/src/components/addCard/index.js
+++ b/src/components/addCard/index.js
@@ -29,6 +29,7 @@ export default class AddCard extends Component {
     activityIndicatorColor: React.PropTypes.string,
     scanCardButtonText: React.PropTypes.string,
     scanCardAfterScanButtonText: React.PropTypes.string,
+    scanCardVisible: React.PropTypes.bool,
     addCardButtonText: React.PropTypes.string,
   }
 
@@ -37,6 +38,7 @@ export default class AddCard extends Component {
     addCardButtonText: 'Add Card',
     scanCardAfterScanButtonText: 'Scan Again',
     scanCardButtonText: 'Scan Card',
+    scanCardVisible: true,
   }
 
   constructor(props) {


### PR DESCRIPTION
Since scanning does not work on iOS #20 I have implemented conditional display of the scan card button. I feel like its a future-proof addition, since we should not assume every user of this library will use the scan functionality.

Great library, thanks for making available!