### PR TITLE
Fixed PropTypes check errors on react native 0.49 or above

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-checkout",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4688,11 +4688,6 @@
         "prompt": "0.2.14",
         "semver": "5.4.1"
       }
-    },
-    "react-native-keyboard-spacer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/react-native-keyboard-spacer/-/react-native-keyboard-spacer-0.3.1.tgz",
-      "integrity": "sha1-lYApfr/QeCAtxMZTA9Kc2jXeZ/E="
     },
     "react-proxy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "lodash": "^4.14.2",
     "payment": "^2.2.1",
+    "prop-types": "^15.6.0",
     "react-native-awesome-card-io": "0.7.0",
     "react-native-keyboard-spacer": "^0.4.1",
     "string": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "^4.14.2",
     "payment": "^2.2.1",
     "react-native-awesome-card-io": "0.7.0",
-    "react-native-keyboard-spacer": "^0.3.0",
+    "react-native-keyboard-spacer": "^0.4.1",
     "string": "^3.3.3"
   },
   "devDependencies": {

--- a/src/components/addCard/index.js
+++ b/src/components/addCard/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { ActivityIndicator, Platform, View, Image, TextInput, Text } from 'react-native'
 import _ from 'lodash'
 import s from 'string'
@@ -16,28 +17,28 @@ import cardCvc from '../../../assets/images/card_cvc.png'
 const DELAY_FOCUS = Platform.OS === 'android' ? 200 : 0
 export default class AddCard extends Component {
   static propTypes = {
-    addCardHandler: React.PropTypes.func.isRequired,
-    onCardNumberBlur: React.PropTypes.func,
-    onCardNumberFocus: React.PropTypes.func,
-    onCvcFocus: React.PropTypes.func,
-    onCvcBlur: React.PropTypes.func,
-    onExpiryBlur: React.PropTypes.func,
-    onExpiryFocus: React.PropTypes.func,
-    onScanCardClose: React.PropTypes.func,
-    onScanCardOpen: React.PropTypes.func,
-    styles: React.PropTypes.object,
-    activityIndicatorColor: React.PropTypes.string,
-    scanCardButtonText: React.PropTypes.string,
-    scanCardAfterScanButtonText: React.PropTypes.string,
-    scanCardVisible: React.PropTypes.bool,
-    addCardButtonText: React.PropTypes.string,
-    placeholderTextColor: React.PropTypes.string,
-    cardNumberPlaceholderText: React.PropTypes.string,
-    expiryPlaceholderText: React.PropTypes.string,
-    cvcPlaceholderText: React.PropTypes.string,
-    cardNumberErrorMessage: React.PropTypes.string,
-    expiryErrorMessage: React.PropTypes.string,
-    cvcErrorMessage: React.PropTypes.string,
+    addCardHandler: PropTypes.func.isRequired,
+    onCardNumberBlur: PropTypes.func,
+    onCardNumberFocus: PropTypes.func,
+    onCvcFocus: PropTypes.func,
+    onCvcBlur: PropTypes.func,
+    onExpiryBlur: PropTypes.func,
+    onExpiryFocus: PropTypes.func,
+    onScanCardClose: PropTypes.func,
+    onScanCardOpen: PropTypes.func,
+    styles: PropTypes.object,
+    activityIndicatorColor: PropTypes.string,
+    scanCardButtonText: PropTypes.string,
+    scanCardAfterScanButtonText: PropTypes.string,
+    scanCardVisible: PropTypes.bool,
+    addCardButtonText: PropTypes.string,
+    placeholderTextColor: PropTypes.string,
+    cardNumberPlaceholderText: PropTypes.string,
+    expiryPlaceholderText: PropTypes.string,
+    cvcPlaceholderText: PropTypes.string,
+    cardNumberErrorMessage: PropTypes.string,
+    expiryErrorMessage: PropTypes.string,
+    cvcErrorMessage: PropTypes.string,
   }
 
   static defaultProps = {

--- a/src/components/selectPayment/index.js
+++ b/src/components/selectPayment/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { View, Text } from 'react-native'
 import _ from 'lodash'
 import PaymentMethods from '../paymentMethods'
@@ -7,13 +8,13 @@ import TouchableOpacity from '../common/touchableOpacity'
 
 export default class SelectPayment extends Component {
   static propTypes = {
-    enableApplePay: React.PropTypes.bool,
-    applePayHandler: React.PropTypes.func,
-    paymentSources: React.PropTypes.array,
-    addCardHandler: React.PropTypes.func.isRequired,
-    selectPaymentHandler: React.PropTypes.func.isRequired,
-    addNewCardText: React.PropTypes.string,
-    styles: React.PropTypes.object,
+    enableApplePay: PropTypes.bool,
+    applePayHandler: PropTypes.func,
+    paymentSources: PropTypes.array,
+    addCardHandler: PropTypes.func.isRequired,
+    selectPaymentHandler: PropTypes.func.isRequired,
+    addNewCardText: PropTypes.string,
+    styles: PropTypes.object,
   }
 
   static defaultProps = {

--- a/src/components/stripeAddCard/index.js
+++ b/src/components/stripeAddCard/index.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { getCardToken } from '../../common/stripe'
 
 import AddCard from '../addCard'
 
 export default class StripeAddCard extends Component {
   static propTypes = {
-    publicStripeKey: React.PropTypes.string.isRequired,
-    addCardTokenHandler: React.PropTypes.func.isRequired,
+    publicStripeKey: PropTypes.string.isRequired,
+    addCardTokenHandler: PropTypes.func.isRequired,
   }
 
   render() {


### PR DESCRIPTION
upgraded dependency of package react-native-keyboard-spacer
added prop-types package
changed all PropTypes references from react package to prop-types package